### PR TITLE
Update RestfulResources to remove Ruby 2.7 Warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,12 @@ PATH
   specs:
     restful_resource_bugsnag (0.4.2)
       bugsnag (~> 6)
-      restful_resource (~> 2)
+      restful_resource (~> 2.10)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,44 +16,45 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    bugsnag (6.11.1)
+    bugsnag (6.18.0)
       concurrent-ruby (~> 1.0)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    faraday (0.15.4)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
-    faraday-cdn-metrics (0.1.0)
-      faraday (~> 0.11)
+      ruby2_keywords
+    faraday-cdn-metrics (0.2.0)
+      faraday (~> 1)
     faraday-encoding (0.0.5)
       faraday
-    faraday-http-cache (2.0.0)
-      faraday (~> 0.8)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
-    ffi (1.11.1)
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    ffi (1.13.1)
     hashdiff (0.3.9)
-    i18n (1.8.2)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     link_header (0.0.8)
-    minitest (5.14.1)
+    minitest (5.14.2)
     multipart-post (2.1.1)
     public_suffix (3.0.3)
     rack (2.2.3)
     rake (13.0.1)
-    restful_resource (2.5.1)
-      activesupport
-      faraday
-      faraday-cdn-metrics
+    restful_resource (2.10.3)
+      activesupport (~> 6.0)
+      faraday (~> 1.0)
+      faraday-cdn-metrics (~> 0.2)
       faraday-encoding
-      faraday-http-cache
-      faraday_middleware
+      faraday-http-cache (~> 2.2)
+      faraday_middleware (~> 1.0)
       link_header
-      rack
-      typhoeus
+      rack (~> 2.2)
+      typhoeus (~> 1.4)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -67,17 +68,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    ruby2_keywords (0.0.2)
     safe_yaml (1.0.5)
     thread_safe (0.3.6)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    zeitwerk (2.3.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby
@@ -90,4 +92,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/restful_resource_bugsnag.gemspec
+++ b/restful_resource_bugsnag.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bugsnag", "~> 6"
-  spec.add_dependency "restful_resource", "~> 2"
+  spec.add_dependency "restful_resource", "~> 2.10"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
It's time to suppress Ruby 2.7 warnings!