### PR TITLE
JSON parse bodies sent to metadata to get keyword filtering for free

### DIFF
--- a/lib/restful_resource_bugsnag/middleware.rb
+++ b/lib/restful_resource_bugsnag/middleware.rb
@@ -50,7 +50,7 @@ module RestfulResourceBugsnag
 
     def attempt_json_parse(string)
       JSON.parse(string)
-    rescue JSON::ParserError
+    rescue JSON::ParserError, TypeError
       string
     end
   end

--- a/lib/restful_resource_bugsnag/middleware.rb
+++ b/lib/restful_resource_bugsnag/middleware.rb
@@ -12,13 +12,13 @@ module RestfulResourceBugsnag
       if exception.is_a?(RestfulResource::HttpClient::HttpError)
         notification.add_tab(:restful_resource_response, {
           status: exception.response.status,
-          body: exception.response.body,
+          body: attempt_json_parse(exception.response.body),
           headers: exception.response.headers
         })
         notification.add_tab(:restful_resource_request, {
           method: exception.request.method,
           url: exception.request.url,
-          body: exception.request.body
+          body: attempt_json_parse(exception.request.body)
         })
       end
 
@@ -46,6 +46,12 @@ module RestfulResourceBugsnag
 
     def request_host_from_exception(exception)
       URI.parse(exception.request.url).host
+    end
+
+    def attempt_json_parse(string)
+      JSON.parse(string)
+    rescue JSON::ParserError
+      string
     end
   end
 end

--- a/spec/restful_resource_bugsnag_spec.rb
+++ b/spec/restful_resource_bugsnag_spec.rb
@@ -86,6 +86,13 @@ describe RestfulResourceBugsnag do
         let(:request_body) { 'The request body' }
       end
     end
+
+    context 'message body is nil' do
+      it_behaves_like 'passes unparsed body to bugsnag' do
+        let(:response_body) { nil }
+        let(:request_body) { nil }
+      end
+    end
   end
 
   describe 'when a notification is sent for an OtherHttpError error' do
@@ -111,6 +118,13 @@ describe RestfulResourceBugsnag do
         let(:request_body) { 'The request body' }
       end
     end
+
+    context 'message body is nil' do
+      it_behaves_like 'passes unparsed body to bugsnag' do
+        let(:response_body) { nil }
+        let(:request_body) { nil }
+      end
+    end
   end
 
   describe 'when a notification is sent for an ServiceUnavailable error' do
@@ -134,6 +148,13 @@ describe RestfulResourceBugsnag do
       it_behaves_like 'passes unparsed body to bugsnag' do
         let(:response_body) { 'Service Unavailable' }
         let(:request_body) { 'The request body' }
+      end
+    end
+
+    context 'message body is nil' do
+      it_behaves_like 'passes unparsed body to bugsnag' do
+        let(:response_body) { nil }
+        let(:request_body) { nil }
       end
     end
 

--- a/spec/restful_resource_bugsnag_spec.rb
+++ b/spec/restful_resource_bugsnag_spec.rb
@@ -16,7 +16,7 @@ describe RestfulResourceBugsnag do
       it { is_expected.to_not be_nil }
       it { is_expected.to include("status" => error.response.status) }
       it { is_expected.to include("headers" => error.response.headers) }
-      it { is_expected.to include("body" => error.response.body) }
+      it { is_expected.to include("body" => JSON.parse(error.response.body)) }
     end
 
     describe 'request tab' do
@@ -25,6 +25,24 @@ describe RestfulResourceBugsnag do
       it { is_expected.to_not be_nil }
       it { is_expected.to include("method" => error.request.method.to_s) }
       it { is_expected.to include("url" => error.request.url) }
+      it { is_expected.to include("body" => JSON.parse(error.request.body)) }
+    end
+  end
+
+  shared_examples 'passes unparsed body to bugsnag' do
+    before do
+      Bugsnag.notify(error)
+    end
+
+    describe 'response tab' do
+      subject(:response_tab) { get_tab(sent_notification, 'restful_resource_response') }
+
+      it { is_expected.to include("body" => error.response.body) }
+    end
+
+    describe 'request tab' do
+      subject(:request_tab) { get_tab(sent_notification, 'restful_resource_request') }
+
       it { is_expected.to include("body" => error.request.body) }
     end
   end
@@ -46,6 +64,8 @@ describe RestfulResourceBugsnag do
   end
 
   describe 'when a notification is sent for an UnprocessableEntity error' do
+    let(:request_body) { '{"msg": "The request body"}' }
+    let(:response_body) { '{"msg": "a body"}' }
     let(:response) do
       {
         :status => 422,
@@ -53,16 +73,24 @@ describe RestfulResourceBugsnag do
           "content-type" => "text/html; charset=utf-8",
           "content-length" => "6"
         },
-        :body => "a body"
+        :body => response_body
       }
     end
+    let(:error) { make_error(RestfulResource::HttpClient::UnprocessableEntity, response, request_body: request_body) }
 
-    it_behaves_like RestfulResourceBugsnag do
-      let(:error) { make_error(RestfulResource::HttpClient::UnprocessableEntity, response) }
+    it_behaves_like RestfulResourceBugsnag
+
+    context 'message body is not valid JSON' do
+      it_behaves_like 'passes unparsed body to bugsnag' do
+        let(:response_body) { 'a body' }
+        let(:request_body) { 'The request body' }
+      end
     end
   end
 
   describe 'when a notification is sent for an OtherHttpError error' do
+    let(:request_body) { '{"msg": "The request body"}' }
+    let(:response_body) { '{"msg": "Server Error"}' }
     let(:response) do
       {
         :status => 500,
@@ -70,16 +98,24 @@ describe RestfulResourceBugsnag do
           "content-type" => "text/html; charset=utf-8",
           "content-length" => "19"
         },
-        :body => "Server Error"
+        :body => response_body
       }
     end
+    let(:error) { make_error(RestfulResource::HttpClient::OtherHttpError, response, request_body: request_body) }
 
-    it_behaves_like RestfulResourceBugsnag do
-      let(:error) { make_error(RestfulResource::HttpClient::OtherHttpError, response) }
+    it_behaves_like RestfulResourceBugsnag
+
+    context 'message body is not valid JSON' do
+      it_behaves_like 'passes unparsed body to bugsnag' do
+        let(:response_body) { 'Server Error' }
+        let(:request_body) { 'The request body' }
+      end
     end
   end
 
   describe 'when a notification is sent for an ServiceUnavailable error' do
+    let(:request_body) { '{"msg": "The request body"}' }
+    let(:response_body) { '{"msg": "Service Unavailable"}' }
     let(:response) do
       {
         :status => 503,
@@ -87,12 +123,18 @@ describe RestfulResourceBugsnag do
           "content-type" => "text/html; charset=utf-8",
           "content-length" => "19"
         },
-        :body => "Service Unavailable"
+        :body => response_body
       }
     end
+    let(:error) { make_error(RestfulResource::HttpClient::ServiceUnavailable, response, request_body: request_body) }
 
-    it_behaves_like RestfulResourceBugsnag do
-      let(:error) { make_error(RestfulResource::HttpClient::ServiceUnavailable, response) }
+    it_behaves_like RestfulResourceBugsnag
+
+    context 'message body is not valid JSON' do
+      it_behaves_like 'passes unparsed body to bugsnag' do
+        let(:response_body) { 'Service Unavailable' }
+        let(:request_body) { 'The request body' }
+      end
     end
 
     describe 'grouping ServiceUnavailable errors' do
@@ -153,14 +195,14 @@ describe RestfulResourceBugsnag do
 
   # this is some what convoluted in order to recreate how
   # errors are sent in a real app using RestfulResource
-  def make_error(type, response, url: 'http://example.com')
+  def make_error(type, response, url: 'http://example.com', request_body: '{"msg": "The request body"}')
     error = nil
 
     begin
       begin
         raise Faraday::ClientError, "The original error"
       rescue Faraday::ClientError => e
-        request = RestfulResource::Request.new(:get, url, body: "The request body")
+        request = RestfulResource::Request.new(:get, url, body: request_body)
         raise type.new(request, response)
       end
     rescue Exception => e


### PR DESCRIPTION
**Original Background**
We sometimes get errors from the IterableEventJob, in a lot of cases we are sending the the request and response bodies which contains PII - we need to scrub this out. We already this in a few places.

Dont worry about 500/400 errors and changing how we handle these for this card, just scrub the PII and added [redacted] or something similar

**Background Update**

After initial research, there are a couple of places where PII is being passed to Bugsnag from this job's errors: RestfulResource error tabs and sidekiq payloads. After speaking to Luke this card is being split into two, with the other linked as a relative.

For this card:
RestfulResource Response and RestfulResource Request tabs are added in the RestfulResourceBugsnag::Middleware. We should update the Bugsnag middleware to scrub PII from the tab contents when reported to Bugsnag be defining default keys to check for and redact.

Luke, however, notes that: "Hard thing is emails within other keys in RR e.g. msg here in the RR response, i dont think we necessarily want to blanket redact certian keys by their name, so it needs to be configurable maybe on a case by case basis or applying some sort of clean to certain keys to remove emails within the key."

So there may have to be some flexibility in terms of what is being redacted. Probably best to speak to Platform or Luke about this.

**AC**

Make sure we are scrubbing PII from error messages in the IterableEventJob RetfulResource tabs we are passing to Bugsnag

**NOTES**
The changes made in previous card around bugsnag config mean that if we pass Ruby objects to the bugsnag gem when raising we get keyword filtering for free. This attempts to parse response and request bodies to JSON, but if it cannot, it passes the raw string to be defensive against itself raising a parse error.

**Screenshot**
![Screenshot 2020-12-15 at 12 55 21](https://user-images.githubusercontent.com/449024/102217661-d1df6700-3ed4-11eb-8e01-04f496f3a2be.png)
