### PR TITLE
Remove user email from bugsnag response tab

### DIFF
--- a/lib/restful_resource_bugsnag/middleware.rb
+++ b/lib/restful_resource_bugsnag/middleware.rb
@@ -57,7 +57,7 @@ module RestfulResourceBugsnag
 
     def redact_user_emails_from_errors(string)
       # Based on Devise.email_regexp
-      string&.gsub(/[^@\s]+@[^@\s]+/, '<email-address-redacted>')
+      string&.gsub(/[^@"\s]+@[^@"\s]+/, '<email-address-redacted>')
     end
   end
 end

--- a/lib/restful_resource_bugsnag/middleware.rb
+++ b/lib/restful_resource_bugsnag/middleware.rb
@@ -49,9 +49,15 @@ module RestfulResourceBugsnag
     end
 
     def attempt_json_parse(string)
-      JSON.parse(string)
+      redacted_string = redact_user_emails_from_errors(string)
+      JSON.parse(redacted_string)
     rescue JSON::ParserError, TypeError
-      string
+      redacted_string
+    end
+
+    def redact_user_emails_from_errors(string)
+      # Based on Devise.email_regexp
+      string&.gsub(/[^@\s]+@[^@\s]+/, '<email-address-redacted>')
     end
   end
 end

--- a/spec/restful_resource_bugsnag_spec.rb
+++ b/spec/restful_resource_bugsnag_spec.rb
@@ -55,8 +55,9 @@ describe RestfulResourceBugsnag do
     describe 'response tab' do
       subject(:response_tab) { get_tab(sent_notification, 'restful_resource_response') }
 
-      it 'replaces an email with a redaction' do
-        expect(subject['body']).to include('Message with email: <email-address-redacted>')
+      it 'replaces an email with a redaction without comprimising the structure of the JSON' do
+        expect(subject['body']).to have_key("msg")
+        expect(subject['body']['msg']).to include('<email-address-redacted>')
       end
     end
   end
@@ -108,10 +109,15 @@ describe RestfulResourceBugsnag do
       end
     end
 
-    context 'message body contains an email address' do
+    context 'message body contains an email address anywhere in the response' do
       it_behaves_like 'redacts emails from body before passing to bugsnag' do
         let(:request_body) { '{"msg": "The request body"}' }
         let(:response_body) { '{"msg": "Message with email: jane@doe.com"}' }
+      end
+
+      it_behaves_like 'redacts emails from body before passing to bugsnag' do
+        let(:request_body) { '{"msg": "The request body"}' }
+        let(:response_body) { '{"msg": "jane@doe.com email in message"}' }
       end
     end
   end
@@ -147,10 +153,15 @@ describe RestfulResourceBugsnag do
       end
     end
 
-    context 'message body contains an email address' do
+    context 'message body contains an email address anywhere in the response' do
       it_behaves_like 'redacts emails from body before passing to bugsnag' do
         let(:request_body) { '{"msg": "The request body"}' }
         let(:response_body) { '{"msg": "Message with email: jane@doe.com"}' }
+      end
+
+      it_behaves_like 'redacts emails from body before passing to bugsnag' do
+        let(:request_body) { '{"msg": "The request body"}' }
+        let(:response_body) { '{"msg": "jane@doe.com email in message"}' }
       end
     end
   end
@@ -186,10 +197,15 @@ describe RestfulResourceBugsnag do
       end
     end
 
-    context 'message body contains an email address' do
+    context 'message body contains an email address anywhere in the response' do
       it_behaves_like 'redacts emails from body before passing to bugsnag' do
         let(:request_body) { '{"msg": "The request body"}' }
         let(:response_body) { '{"msg": "Message with email: jane@doe.com"}' }
+      end
+
+      it_behaves_like 'redacts emails from body before passing to bugsnag' do
+        let(:request_body) { '{"msg": "The request body"}' }
+        let(:response_body) { '{"msg": "jane@doe.com email in message"}' }
       end
     end
 

--- a/spec/restful_resource_bugsnag_spec.rb
+++ b/spec/restful_resource_bugsnag_spec.rb
@@ -47,6 +47,20 @@ describe RestfulResourceBugsnag do
     end
   end
 
+  shared_examples 'redacts emails from body before passing to bugsnag' do
+    before do
+      Bugsnag.notify(error)
+    end
+
+    describe 'response tab' do
+      subject(:response_tab) { get_tab(sent_notification, 'restful_resource_response') }
+
+      it 'replaces an email with a redaction' do
+        expect(subject['body']).to include('<email-address-redacted>')
+      end
+    end
+  end
+
   it 'has a version number' do
     expect(RestfulResourceBugsnag::VERSION).not_to be nil
   end
@@ -93,6 +107,13 @@ describe RestfulResourceBugsnag do
         let(:request_body) { nil }
       end
     end
+
+    context 'message body contains an email address' do
+      it_behaves_like 'redacts emails from body before passing to bugsnag' do
+        let(:request_body) { '{"msg": "The request body"}' }
+        let(:response_body) { '{"msg": "Message with email jane@doe.com"}' }
+      end
+    end
   end
 
   describe 'when a notification is sent for an OtherHttpError error' do
@@ -125,6 +146,13 @@ describe RestfulResourceBugsnag do
         let(:request_body) { nil }
       end
     end
+
+    context 'message body contains an email address' do
+      it_behaves_like 'redacts emails from body before passing to bugsnag' do
+        let(:request_body) { '{"msg": "The request body"}' }
+        let(:response_body) { '{"msg": "Message with email jane@doe.com"}' }
+      end
+    end
   end
 
   describe 'when a notification is sent for an ServiceUnavailable error' do
@@ -155,6 +183,13 @@ describe RestfulResourceBugsnag do
       it_behaves_like 'passes unparsed body to bugsnag' do
         let(:response_body) { nil }
         let(:request_body) { nil }
+      end
+    end
+
+    context 'message body contains an email address' do
+      it_behaves_like 'redacts emails from body before passing to bugsnag' do
+        let(:request_body) { '{"msg": "The request body"}' }
+        let(:response_body) { '{"msg": "Message with email jane@doe.com"}' }
       end
     end
 

--- a/spec/restful_resource_bugsnag_spec.rb
+++ b/spec/restful_resource_bugsnag_spec.rb
@@ -56,7 +56,7 @@ describe RestfulResourceBugsnag do
       subject(:response_tab) { get_tab(sent_notification, 'restful_resource_response') }
 
       it 'replaces an email with a redaction' do
-        expect(subject['body']).to include('<email-address-redacted>')
+        expect(subject['body']).to include('Message with email: <email-address-redacted>')
       end
     end
   end
@@ -111,7 +111,7 @@ describe RestfulResourceBugsnag do
     context 'message body contains an email address' do
       it_behaves_like 'redacts emails from body before passing to bugsnag' do
         let(:request_body) { '{"msg": "The request body"}' }
-        let(:response_body) { '{"msg": "Message with email jane@doe.com"}' }
+        let(:response_body) { '{"msg": "Message with email: jane@doe.com"}' }
       end
     end
   end
@@ -150,7 +150,7 @@ describe RestfulResourceBugsnag do
     context 'message body contains an email address' do
       it_behaves_like 'redacts emails from body before passing to bugsnag' do
         let(:request_body) { '{"msg": "The request body"}' }
-        let(:response_body) { '{"msg": "Message with email jane@doe.com"}' }
+        let(:response_body) { '{"msg": "Message with email: jane@doe.com"}' }
       end
     end
   end
@@ -189,7 +189,7 @@ describe RestfulResourceBugsnag do
     context 'message body contains an email address' do
       it_behaves_like 'redacts emails from body before passing to bugsnag' do
         let(:request_body) { '{"msg": "The request body"}' }
-        let(:response_body) { '{"msg": "Message with email jane@doe.com"}' }
+        let(:response_body) { '{"msg": "Message with email: jane@doe.com"}' }
       end
     end
 


### PR DESCRIPTION
https://carwow.kanbanize.com/ctrl_board/25/cards/31078/details/

User email address are still appearing in Bugsnag errors. We have configured Bugsnag to look for certain keys and filter out the values. So this works while there is a `name`/`email`/`password` key. But Iterable returns a `msg` key providing some detail on the error. Within this message they include email address

I have take some inspiration from the [redaction of email addresses from DB constraint errors](https://github.com/carwow/quotes_site/pull/14231) in quotes site. I am not a big fan of just duplicating this behaviour here but not sure if there is a better way to handle this